### PR TITLE
Fix: Allow NULL output parameters

### DIFF
--- a/libdwarf/dwarf_die_deliv.c
+++ b/libdwarf/dwarf_die_deliv.c
@@ -1257,7 +1257,9 @@ _dwarf_next_cu_header_internal(Dwarf_Debug dbg,
     /*  Determine the offset of the next CU. */
     new_offset = new_offset + cu_context->cc_length +
         cu_context->cc_length_size + cu_context->cc_extension_size;
-    *next_cu_offset = new_offset;
+    if (next_cu_offset) {
+        *next_cu_offset = new_offset;
+    }
     return (DW_DLV_OK);
 }
 

--- a/libdwarf/dwarf_query.c
+++ b/libdwarf/dwarf_query.c
@@ -1259,8 +1259,12 @@ dwarf_highpc_b(Dwarf_Die die,
                 }
             }
             *return_value = addr_out;
-            *return_form = attr_form;
-            *return_class = class;
+            if (return_form) {
+                *return_form = attr_form;
+            }
+            if (return_class) {
+                *return_class = class;
+            }
             return (DW_DLV_OK);
         }
 
@@ -1299,8 +1303,12 @@ dwarf_highpc_b(Dwarf_Die die,
             *return_value = v;
         }
     }
-    *return_form = attr_form;
-    *return_class = class;
+    if (return_form) {
+        *return_form = attr_form;
+    }
+    if (return_class) {
+        *return_class = class;
+    }
     return DW_DLV_OK;
 }
 


### PR DESCRIPTION
Documentation says that these parameters can be NULL if the caller does not need them.