### PR TITLE
Suppress warnings

### DIFF
--- a/dwarfdump/configure.cmake
+++ b/dwarfdump/configure.cmake
@@ -2,8 +2,8 @@ include(AutoconfHelper)
 
 ac_init()
 ac_check_headers(elf.h libelf.h libelf/libelf.h sgidefs.h sys/types.h stdafx.h Windows.h)
-ac_check_lib(${LIBELF_LIBRARIES} elf elf32_getehdr)
-ac_check_lib(${LIBELF_LIBRARIES} elf elf64_getehdr)
+ac_check_lib(${LIBELF_LIBRARIES} elf32_getehdr)
+ac_check_lib(${LIBELF_LIBRARIES} elf64_getehdr)
 
 # Find out where the elf header is.
 if(HAVE_ELF_H)

--- a/libdwarf/configure.cmake
+++ b/libdwarf/configure.cmake
@@ -7,8 +7,8 @@ ac_check_headers(alloca.h elf.h elfaccess.h libelf.h libelf/libelf.h  sys/types.
 message(STATUS "Assuming struct Elf for the default libdwarf.h")
 configure_file(libdwarf.h.in libdwarf.h COPYONLY)
 
-ac_check_lib(${LIBELF_LIBRARIES} elf elf64_getehdr)
-ac_check_lib(${LIBELF_LIBRARIES} elf elf64_getshdr)
+ac_check_lib(${LIBELF_LIBRARIES} elf64_getehdr)
+ac_check_lib(${LIBELF_LIBRARIES} elf64_getshdr)
 
 # Find out where the elf header is.
 if(HAVE_ELF_H)

--- a/libdwarf/dwarf_die_deliv.c
+++ b/libdwarf/dwarf_die_deliv.c
@@ -2216,10 +2216,10 @@ dwarf_get_real_section_name(Dwarf_Debug dbg,
     Dwarf_Unsigned *uncompressed_length,
     Dwarf_Error *error)
 {
-    struct Dwarf_dbg_sect_s *secdata;
-    struct Dwarf_Section_s *ds_secdata;
+    /* struct Dwarf_dbg_sect_s *secdata; */
+    /* struct Dwarf_Section_s *ds_secdata; */
     unsigned i = 0;
-    unsigned array_used = 0;
+    /* unsigned array_used = 0; */
     char tbuf[50];
     unsigned std_sec_name_len = strlen(std_section_name);
 

--- a/libdwarf/pro_section.c
+++ b/libdwarf/pro_section.c
@@ -3070,7 +3070,7 @@ _dwarf_pro_generate_debuginfo(Dwarf_P_Debug dbg,
         char *space = 0;
         int cres = 0;
         char buff1[ENCODE_SPACE_NEEDED];
-        int i = 0;
+        /* int i = 0; */
 
         curdie->di_offset = die_off;
 


### PR DESCRIPTION
hi, could you acknowledge this? We need to suppress warnings because the build test by autotest treats warnings as errors.
